### PR TITLE
releasetools: don't attempt to read fingerprint on unified devices

### DIFF
--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -474,6 +474,8 @@ def GetOemProperty(name, oem_props, oem_dict, info_dict):
 
 
 def CalculateFingerprint(oem_props, oem_dict, info_dict):
+  if OPTIONS.override_prop:
+    return GetBuildProp("ro.build.date.utc", info_dict)
   if oem_props is None:
     return GetBuildProp("ro.build.fingerprint", info_dict)
   return "%s/%s/%s:%s" % (


### PR DESCRIPTION
* You wont find this in the build.prop on these devices and this is
  how we handled them in previous versions

=======

This is only a part of the commit. The rest of this commit was introduced
in https://github.com/omnirom/android_build/commit/63b70a828769ad04d1e73496e555185ab8e90d01

So adding this part is fixing that commit with respect to the original author
Change-Id: I11e2647931c38d1ff025a8a6bc89bb7dc6cd6e84